### PR TITLE
Fixes for map spec

### DIFF
--- a/src/speculative/core.cljc
+++ b/src/speculative/core.cljc
@@ -3,8 +3,8 @@
             [clojure.spec.test.alpha :as stest]))
 
 (s/fdef clojure.core/map
-  :args (s/cat :f fn? :colls (s/? sequential?))
-  :ret sequential?)
+  :args (s/cat :f ifn? :colls (s/? (s/nilable seqable?)))
+  :ret seq?)
 
 
 


### PR DESCRIPTION
Map spec needs 

- `ifn?` instead of `fn?` so you can do `(map {0 1, 1 2} (range 2))`
- `seqable? instead of `sequential?` so you can do `(map identity "abc")`
- `nilable` so you can do `(map identity nil)`

And the return type can be tightened to satisfying `seq?`
